### PR TITLE
fix: change url for health check for consul

### DIFF
--- a/package/carbonio-chats-messaging-db.hcl
+++ b/package/carbonio-chats-messaging-db.hcl
@@ -5,11 +5,7 @@ services {
     interval = "5s"
   }
   connect {
-    sidecar_service {
-      proxy {
-        local_service_address = "127.78.0.103"
-      }
-    }
+    sidecar_service {}
   }
   name = "carbonio-chats-messaging-db"
   port = 5432


### PR DESCRIPTION
Change health check to go on localhost since it's where the db or pgpool will respond, this will only check if it's reachable