### PR TITLE
fix: restore buildPackages() to fix pkgrel on tag builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,8 +72,10 @@ pipeline {
             steps {
                 script {
                     buildPackages([
+                        pkgbuildPath: 'package/PKGBUILD',
                         buildStageConfig: [
-                            buildFlags: '-ds',
+                            rockySinglePkg: true,
+                            ubuntuSinglePkg: true
                         ]
                     ])
                 }
@@ -90,6 +92,8 @@ pipeline {
             steps {
                 uploadStage(
                     packages: yapHelper.resolvePackageNames(),
+                    rockySinglePkg: true,
+                    ubuntuSinglePkg: true
                 )
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,8 +71,10 @@ pipeline {
         stage('Build deb/rpm') {
             steps {
                 script {
-                    buildStage([
-                        buildFlags: '-ds',
+                    buildPackages([
+                        buildStageConfig: [
+                            buildFlags: '-ds',
+                        ]
                     ])
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,6 +74,7 @@ pipeline {
                     buildPackages([
                         pkgbuildPath: 'package/PKGBUILD',
                         buildStageConfig: [
+                            buildFlags: ' -ds ',
                             rockySinglePkg: true,
                             ubuntuSinglePkg: true
                         ]


### PR DESCRIPTION
## Summary
- Restores `buildPackages()` wrapper that was removed in CO-3422 batch commit (Apr 8)
- `buildStage()` alone does not call `updatePkgbuildRelease()`, causing SNAPSHOT pkgrel to leak into RC artifacts on tag builds
- `buildPackages()` calls `updatePkgbuildRelease()` → `buildStage()` → git checkout, ensuring pkgrel=1 on releases

## Test plan
- [ ] Verify devel branch build still produces SNAPSHOT packages
- [ ] Verify tag build produces pkgrel=1 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)