### PR TITLE
chore: bump jenkins-lib-common to 1.7.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ library(
 )
 
 library(
-    identifier: 'jenkins-lib-common@1.7.0',
+    identifier: 'jenkins-lib-common@1.7.5',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
## Summary

- Bump `jenkins-lib-common` from current version to `1.7.5` in `Jenkinsfile`
- Part of JFrog cost optimization initiative (IN-1095)