### PR TITLE
fix(ci): build packages for all distros

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ dt3_pipeline(
     packaging: [
         pkgbuildPath: 'package/PKGBUILD',
         buildFlags: '-ds',
+        rockySinglePkg: false,
+        ubuntuSinglePkg: false,
     ],
     docker: [[
         dockerfile: 'docker/sidecar/Dockerfile',


### PR DESCRIPTION
## Summary

Fixes CO-3709: packages were only being built for a single distro variant because `rockySinglePkg` and `ubuntuSinglePkg` defaulted to `true` inside `dt3_pipeline()`.

## Problem

After the migration to `dt3_pipeline()` (PR #60), the `packaging` map did not explicitly set `rockySinglePkg`/`ubuntuSinglePkg`, so the pipeline fell back to the library default of `true`, producing only one package per distro instead of the full set.

## Fix

Add `rockySinglePkg: false` and `ubuntuSinglePkg: false` to the `packaging` map so all distro packages are built.

## References

- [CO-3709](https://zextras.atlassian.net/browse/CO-3709)

[CO-3709]: https://zextras.atlassian.net/browse/CO-3709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ